### PR TITLE
Fix nativeTest

### DIFF
--- a/src/test/resources/META-INF/native-image/org.junit/junit-jupiter/5.11.0-M2/native-image.properties
+++ b/src/test/resources/META-INF/native-image/org.junit/junit-jupiter/5.11.0-M2/native-image.properties
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Args = --initialize-at-build-time=org.junit.platform.commons.util.LruCache


### PR DESCRIPTION
- fix issue https://github.com/graalvm/native-build-tools/issues/602 . For https://github.com/graalvm/native-build-tools/pull/603 .
```shell
$ ./mvnw -PnativeTestInJunit -T1C -e clean test
[INFO] Error stacktraces are turned on.
[INFO] Scanning for projects...
[INFO] 
[INFO] Using the MultiThreadedBuilder implementation with a thread count of 16
[INFO] 
[INFO] ---------------------< com.lingh:junit-v5110-test >---------------------
[INFO] Building junit-v5110-test 1.0-SNAPSHOT
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- clean:3.2.0:clean (default-clean) @ junit-v5110-test ---
[INFO] Deleting /home/linghengqian/TwinklingLiftWorks/git/public/junit-v5110-test/target
[INFO] 
[INFO] --- resources:3.3.1:resources (default-resources) @ junit-v5110-test ---
[INFO] skip non existing resourceDirectory /home/linghengqian/TwinklingLiftWorks/git/public/junit-v5110-test/src/main/resources
[INFO] 
[INFO] --- compiler:3.11.0:compile (default-compile) @ junit-v5110-test ---
[INFO] No sources to compile
[INFO] 
[INFO] --- resources:3.3.1:testResources (default-testResources) @ junit-v5110-test ---
[INFO] Copying 1 resource from src/test/resources to target/test-classes
[INFO] 
[INFO] --- compiler:3.11.0:testCompile (default-testCompile) @ junit-v5110-test ---
[INFO] Changes detected - recompiling the module! :source
[INFO] Compiling 1 source file with javac [debug target 22] to target/test-classes
[INFO] 
[INFO] --- surefire:3.2.2:test (default-test) @ junit-v5110-test ---
[WARNING]  Parameter 'systemProperties' is deprecated: Use systemPropertyVariables instead.
[INFO] Surefire report directory: /home/linghengqian/TwinklingLiftWorks/git/public/junit-v5110-test/target/surefire-reports
[INFO] Using auto detected provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running com.lingh.ClassLevelTest
[WARNING] Tests run: 1, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.007 s -- in com.lingh.ClassLevelTest
[INFO] 
[INFO] Results:
[INFO] 
[WARNING] Tests run: 1, Failures: 0, Errors: 0, Skipped: 1
[INFO] 
[INFO] 
[INFO] --- native:0.10.2:test (test-native) @ junit-v5110-test ---
[INFO] ====================
[INFO] Initializing project: junit-v5110-test
[INFO] ====================
[INFO] Found GraalVM installation from JAVA_HOME variable.
[INFO] Downloaded GraalVM reachability metadata repository from file:/home/linghengqian/.m2/repository/org/graalvm/buildtools/graalvm-reachability-metadata/0.10.2/graalvm-reachability-metadata-0.10.2-repository.zip
[INFO] Executing: /home/linghengqian/.sdkman/candidates/java/22.0.1-graalce/bin/native-image -cp /home/linghengqian/TwinklingLiftWorks/git/public/junit-v5110-test/target/test-classes:/home/linghengqian/TwinklingLiftWorks/git/public/junit-v5110-test/src/test/resources:/home/linghengqian/.m2/repository/org/junit/jupiter/junit-jupiter/5.11.0-M2/junit-jupiter-5.11.0-M2.jar:/home/linghengqian/.m2/repository/org/junit/jupiter/junit-jupiter-api/5.11.0-M2/junit-jupiter-api-5.11.0-M2.jar:/home/linghengqian/.m2/repository/org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.jar:/home/linghengqian/.m2/repository/org/junit/platform/junit-platform-commons/1.11.0-M2/junit-platform-commons-1.11.0-M2.jar:/home/linghengqian/.m2/repository/org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar:/home/linghengqian/.m2/repository/org/junit/jupiter/junit-jupiter-params/5.11.0-M2/junit-jupiter-params-5.11.0-M2.jar:/home/linghengqian/.m2/repository/org/junit/jupiter/junit-jupiter-engine/5.11.0-M2/junit-jupiter-engine-5.11.0-M2.jar:/home/linghengqian/.m2/repository/org/junit/platform/junit-platform-engine/1.11.0-M2/junit-platform-engine-1.11.0-M2.jar:/home/linghengqian/.m2/repository/org/graalvm/buildtools/native-maven-plugin/0.10.2/native-maven-plugin-0.10.2.jar:/home/linghengqian/.m2/repository/org/graalvm/buildtools/utils/0.10.2/utils-0.10.2.jar:/home/linghengqian/.m2/repository/org/graalvm/buildtools/graalvm-reachability-metadata/0.10.2/graalvm-reachability-metadata-0.10.2.jar:/home/linghengqian/.m2/repository/org/graalvm/buildtools/junit-platform-native/0.10.2/junit-platform-native-0.10.2.jar:/home/linghengqian/.m2/repository/org/junit/platform/junit-platform-console/1.10.0/junit-platform-console-1.10.0.jar:/home/linghengqian/.m2/repository/org/junit/platform/junit-platform-reporting/1.10.0/junit-platform-reporting-1.10.0.jar:/home/linghengqian/.m2/repository/org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar:/home/linghengqian/.m2/repository/org/junit/platform/junit-platform-launcher/1.10.0/junit-platform-launcher-1.10.0.jar:/home/linghengqian/.m2/repository/org/junit/platform/junit-platform-engine/1.10.0/junit-platform-engine-1.10.0.jar:/home/linghengqian/.m2/repository/org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.jar:/home/linghengqian/.m2/repository/org/junit/platform/junit-platform-commons/1.10.0/junit-platform-commons-1.10.0.jar:/home/linghengqian/.m2/repository/org/junit/jupiter/junit-jupiter/5.10.0/junit-jupiter-5.10.0.jar:/home/linghengqian/.m2/repository/org/junit/jupiter/junit-jupiter-api/5.10.0/junit-jupiter-api-5.10.0.jar:/home/linghengqian/.m2/repository/org/junit/jupiter/junit-jupiter-params/5.10.0/junit-jupiter-params-5.10.0.jar:/home/linghengqian/.m2/repository/org/junit/jupiter/junit-jupiter-engine/5.10.0/junit-jupiter-engine-5.10.0.jar --no-fallback -Ob -o /home/linghengqian/TwinklingLiftWorks/git/public/junit-v5110-test/target/native-tests -Djunit.platform.listeners.uid.tracking.output.dir=/home/linghengqian/TwinklingLiftWorks/git/public/junit-v5110-test/target/test-ids --features=org.graalvm.junit.platform.JUnitPlatformFeature org.graalvm.junit.platform.NativeImageJUnitLauncher
========================================================================================================================
GraalVM Native Image: Generating 'native-tests' (executable)...
========================================================================================================================
[1/8] Initializing...                                                                                    (4.5s @ 0.11GB)
 Java version: 22.0.1+8, vendor version: GraalVM CE 22.0.1+8.1
 Graal compiler: optimization level: b, target machine: x86-64-v3
 C compiler: gcc (linux, x86_64, 11.4.0)
 Garbage collector: Serial GC (max heap size: 80% of RAM)
 2 user-specific feature(s):
 - com.oracle.svm.thirdparty.gson.GsonFeature
 - org.graalvm.junit.platform.JUnitPlatformFeature
------------------------------------------------------------------------------------------------------------------------
Build resources:
 - 10.57GB of memory (54.1% of 19.54GB system memory, determined at start)
 - 16 thread(s) (100.0% of 16 available processor(s), determined at start)
[junit-platform-native] Running in 'test listener' mode using files matching pattern [junit-platform-unique-ids*] found in folder [/home/linghengqian/TwinklingLiftWorks/git/public/junit-v5110-test/target/test-ids] and its subfolders.
[2/8] Performing analysis...  [****]                                                                    (12.1s @ 0.74GB)
    6,819 reachable types   (81.3% of    8,389 total)
    9,295 reachable fields  (51.0% of   18,210 total)
   30,316 reachable methods (52.4% of   57,903 total)
    2,358 types,    72 fields, and   883 methods registered for reflection
       58 types,    58 fields, and    52 methods registered for JNI access
        4 native libraries: dl, pthread, rt, z
[3/8] Building universe...                                                                               (2.8s @ 0.75GB)
[4/8] Parsing methods...      [*]                                                                        (1.3s @ 0.61GB)
[5/8] Inlining methods...     [***]                                                                      (1.0s @ 0.76GB)
[6/8] Compiling methods...    [***]                                                                      (5.8s @ 0.91GB)
[7/8] Laying out methods...   [**]                                                                       (2.2s @ 0.72GB)
[8/8] Creating image...       [**]                                                                       (2.1s @ 1.15GB)
  12.79MB (43.40%) for code area:    18,268 compilation units
  15.34MB (52.08%) for image heap:  169,780 objects and 241 resources
   1.33MB ( 4.52%) for other data
  29.46MB in total
------------------------------------------------------------------------------------------------------------------------
Top 10 origins of code area:                                Top 10 object types in image heap:
   6.70MB java.base                                            3.95MB byte[] for code metadata
   3.94MB java.xml                                             2.36MB byte[] for java.lang.String
 974.01kB svm.jar (Native Image)                               1.65MB java.lang.String
 229.59kB junit-jupiter-engine-5.11.0-M2.jar                   1.64MB java.lang.Class
 148.67kB junit-platform-launcher-1.10.0.jar                 586.01kB com.oracle.svm.core.hub.DynamicHubCompanion
 117.12kB java.logging                                       513.00kB int[][]
 103.92kB junit-platform-engine-1.11.0-M2.jar                502.60kB heap alignment
 103.64kB junit-platform-commons-1.11.0-M2.jar               494.99kB byte[] for general heap data
  95.24kB junit-platform-reporting-1.10.0.jar                351.84kB java.lang.String[]
  57.00kB org.graalvm.nativeimage.base                       330.19kB java.util.HashMap$Node
 243.52kB for 13 more packages                                 3.04MB for 1630 more object types
------------------------------------------------------------------------------------------------------------------------
Recommendations:
 HEAP: Set max heap for improved and more predictable memory usage.
 CPU:  Enable more CPU features with '-march=native' for improved performance.
------------------------------------------------------------------------------------------------------------------------
                        3.1s (9.0% of total time) in 122 GCs | Peak RSS: 1.89GB | CPU load: 9.16
------------------------------------------------------------------------------------------------------------------------
Build artifacts:
 /home/linghengqian/TwinklingLiftWorks/git/public/junit-v5110-test/target/native-tests (executable)
========================================================================================================================
Finished generating 'native-tests' in 32.8s.
[INFO] Executing: /home/linghengqian/TwinklingLiftWorks/git/public/junit-v5110-test/target/native-tests --xml-output-dir /home/linghengqian/TwinklingLiftWorks/git/public/junit-v5110-test/target/native-test-reports -Djunit.platform.listeners.uid.tracking.output.dir=/home/linghengqian/TwinklingLiftWorks/git/public/junit-v5110-test/target/test-ids
JUnit Platform on Native Image - report
----------------------------------------

com.lingh.ClassLevelTest > testOnClass() SUCCESSFUL


Test run finished after 2 ms
[         2 containers found      ]
[         0 containers skipped    ]
[         2 containers started    ]
[         0 containers aborted    ]
[         2 containers successful ]
[         0 containers failed     ]
[         1 tests found           ]
[         0 tests skipped         ]
[         1 tests started         ]
[         0 tests aborted         ]
[         1 tests successful      ]
[         0 tests failed          ]

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  36.216 s (Wall Clock)
[INFO] Finished at: 2024-06-13T23:12:38+08:00
[INFO] ------------------------------------------------------------------------
```